### PR TITLE
restrict selenium version to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cd ruby-selenium-sample
 ```
 Install selenium dependencies for Ruby automation testing.
 ```bash
-sudo gem install selenium-webdriver
+sudo gem install selenium-webdriver -v 3.142.7
 ```
 ### Setting up Your Authentication
 Make sure you have your LambdaTest credentials with you to run test automation scripts with Jest on LambdaTest Selenium Grid. You can obtain these credentials from the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=ruby-selenium-sample) or through LambdaTest Profile.

--- a/todo-click-test.rb
+++ b/todo-click-test.rb
@@ -35,7 +35,7 @@ class LtTest < Test::Unit::TestCase
  
         caps = {                       
             :browserName => "chrome",         
-            :version =>   "67.0",         
+            :version =>   "latest",         
             :platform =>  "win10",
             :name =>  "LambdaTest ruby google search name",
             :build =>  "LambdaTest ruby google search build",      


### PR DESCRIPTION
gem install commands installs selenium version 4+ which makes the existing tests fail.
Selenium 4 handling will be done in separate branch. CC @sururocks 